### PR TITLE
Raise an argument exception if args are nil

### DIFF
--- a/lib/twitter/identity.rb
+++ b/lib/twitter/identity.rb
@@ -13,6 +13,8 @@ module Twitter
     # @raise [ArgumentError] Error raised when supplied argument is missing an :id key.
     # @return [Twitter::Identity]
     def initialize(attrs = {})
+      raise ArgumentError, 'attrs nil' unless attrs
+
       attrs.fetch(:id)
       super
     end

--- a/spec/twitter/identifiable_spec.rb
+++ b/spec/twitter/identifiable_spec.rb
@@ -5,6 +5,10 @@ describe Twitter::Identity do
     it 'raises an IndexError when id is not specified' do
       expect { Twitter::Identity.new }.to raise_error(IndexError)
     end
+
+    it 'raises an argument error when args are nil' do
+      expect { Twitter::Identity.new(nil) }.to raise_error(ArgumentError)
+    end
   end
 
   describe '#==' do


### PR DESCRIPTION
If you attempt to upload a file larger than the twitter limit (3or5mb),
a Tweet will be created with args == nil. This handles that by raising
an argument exception. Without this you
get `undefined method`fetch' for nil:NilClass`.
